### PR TITLE
Adding a Django development environment

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,6 +17,13 @@ Vagrant.configure("2") do |config|
   config.vm.provider "virtualbox" do |vb|
   vb.memory = "1024"
   end
+  
+  config.vm.network(
+  "forwarded_port", guest: 8000, host: 8000, host_ip: "127.0.0.1"
+  )
+  
+  config.vm.provision "shell", path: "setup.sh", privileged: false
+
 
 
   # Disable automatic box update checking. If you disable this, then

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -ex
+# The -e option would make our script exit with an error if any command
+# fails while the -x option makes verbosely it output what it does
+
+# Install Pipenv, the -n option makes sudo fail instead of asking for a
+# password if we don't have sufficient privileges to run it
+sudo -n dnf install -y pipenv
+
+cd /vagrant
+# Install dependencies with Pipenv
+pipenv sync --dev
+
+# run our app. Nohup and "&" are used to let the setup script finish
+# while our app stays up. The app logs will be collected in nohup.out
+nohup pipenv run python manage.py runserver 0.0.0.0:8000 &


### PR DESCRIPTION
- Setup [Pipenv][1] to install and manage Django and other Python
  dependencies
- Bootstrapped an empty [Django][2] application
- Setup Vagrant to automatically bring our application up as well as
  make it accessible from a web browser

After running `vagrant up` the application can be accessed at:

> http://127.0.0.1:8000/

**Note:** Most changes had been auto-generated, only `Vagrantfile` and
`steup.sh` had been edited manually.

[1]: https://github.com/pypa/pipenv
[2]: https://www.djangoproject.com/